### PR TITLE
TypeErase template: support throwing methods.

### DIFF
--- a/templates/TypeErase.swifttemplate
+++ b/templates/TypeErase.swifttemplate
@@ -62,7 +62,7 @@ private class _Any<%=type.name%>Base<%=genericTypesModifier%>: <%=type.name%><%=
     <%_ if !allMethods.isEmpty { -%>
 
     <%_ for m in allMethods { -%>
-    func <%=m.name%> -> <%=m.returnTypeName%> {
+    func <%=m.name%><%=m.throws ? " throws" : ""%> -> <%=m.returnTypeName%> {
         fatalError("Must override")
     }
     <%_ } -%>
@@ -90,8 +90,8 @@ private final class _Any<%=type.name%>Box<Concrete: <%=type.name%>>: _Any<%=type
     <%_ if !allMethods.isEmpty { -%>
 
     <%_ for m in allMethods { -%>
-    override func <%=m.name%> -> <%=m.returnTypeName%> {
-        return concrete.<%=m.callName%>(<%= m.parameters.map { "\($0.argumentLabel != nil ? "\($0.argumentLabel!): " : "")\($0.`inout` ? "inout ": "")\($0.name)" }.joined(separator: ", ") %>)
+    override func <%=m.name%><%=m.throws ? " throws" : ""%> -> <%=m.returnTypeName%> {
+        return <%=m.throws ? "try " : ""%>concrete.<%=m.callName%>(<%= m.parameters.map { "\($0.argumentLabel != nil ? "\($0.argumentLabel!): " : "")\($0.`inout` ? "inout ": "")\($0.name)" }.joined(separator: ", ") %>)
     }
     <%_ } -%>
     <%_ } -%>
@@ -115,8 +115,8 @@ final class Any<%=type.name%><%=genericTypesModifier%>: <%=type.name%><%=generic
     <%_ if !allMethods.isEmpty { -%>
 
     <%_ for m in allMethods { -%>
-    func <%=m.name%> -> <%=m.returnTypeName%> {
-        return box.<%=m.callName%>(<%= m.parameters.map { "\($0.argumentLabel != nil ? "\($0.argumentLabel!): " : "")\($0.`inout` ? "inout ": "")\($0.name)" }.joined(separator: ", ") %>)
+    func <%=m.name%><%=m.throws ? " throws" : ""%> -> <%=m.returnTypeName%> {
+        return <%=m.throws ? "try " : ""%>box.<%=m.callName%>(<%= m.parameters.map { "\($0.argumentLabel != nil ? "\($0.argumentLabel!): " : "")\($0.`inout` ? "inout ": "")\($0.name)" }.joined(separator: ", ") %>)
     }
     <%_ } -%>
     <%_ } -%>

--- a/tests/SwiftSourceryTemplates/SwiftSourceryTemplates/Protocols/Protocols.swift
+++ b/tests/SwiftSourceryTemplates/SwiftSourceryTemplates/Protocols/Protocols.swift
@@ -139,6 +139,14 @@ protocol ErrorPopoverPresentableRawRepresentable {
 }
 
 /// sourcery: CreateMock
+/// sourcery: TypeErase
+/// sourcery: associatedtype = "EventType"
+protocol ThrowingGenericBuildable {
+    associatedtype EventType
+    func build() throws -> AnyErrorPopoverPresentable<EventType>
+}
+
+/// sourcery: CreateMock
 protocol TipsManaging: class {
     var tips: [String: String] { get }
     var tipsOptional: [String: String]? { get }

--- a/tests/SwiftSourceryTemplates/SwiftSourceryTemplatesTests/Mocks/Mocks.generated.swift
+++ b/tests/SwiftSourceryTemplates/SwiftSourceryTemplatesTests/Mocks/Mocks.generated.swift
@@ -525,6 +525,24 @@ class SomeRoutingMock<_InteractorType>: SomeRouting where _InteractorType: SomeI
     }
 }
 
+// MARK: - ThrowingGenericBuildable
+class ThrowingGenericBuildableMock<_EventType>: ThrowingGenericBuildable {
+
+    // MARK: - Generic typealiases
+    typealias EventType = _EventType
+
+    // MARK: - Methods
+    func build() throws -> AnyErrorPopoverPresentable<EventType> {
+        buildCallCount += 1
+        if let __buildHandler = self.buildHandler {
+            return try __buildHandler()
+        }
+        fatalError("buildHandler expected to be set.")
+    }
+    var buildCallCount: Int = 0
+    var buildHandler: (() throws -> (AnyErrorPopoverPresentable<EventType>))? = nil
+}
+
 // MARK: - ThumbCreating
 class ThumbCreatingMock: ThumbCreating {
 


### PR DESCRIPTION
Summary:
Add support for protocol methods marked with `throws` attribute:
```
/// sourcery: TypeErase
/// sourcery: associatedtype = "EventType"
protocol ThrowingGenericBuildable {
    associatedtype EventType
    func build() throws -> AnyErrorPopoverPresentable<EventType>
}
```